### PR TITLE
Better diff log

### DIFF
--- a/libyamlconf/__init__.py
+++ b/libyamlconf/__init__.py
@@ -117,4 +117,4 @@ Which would then also result in:
       - gdbserver
 """
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/libyamlconf/verify.py
+++ b/libyamlconf/verify.py
@@ -38,9 +38,10 @@ def load_and_verify(
     # Check for not used parameters
     model_data = instance.model_dump()
     if model_data != data:
-        logging.warning(
-            "The config file contains not used parameters! Difference to loaded model:\n%s", DeepDiff(data, model_data)
-        )
+        diff = DeepDiff(data, model_data)
+        for key in diff.keys():
+            if "removed" in key:  # pragma: no branch
+                logging.warning("The config file contains not used parameters! %s", diff[key])
 
     return instance
 


### PR DESCRIPTION
Only log if resulting object has less data than the base dict.
This avoids warning logs on fields using default values.